### PR TITLE
Add media devicePermissions to enable camera/mic access

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -44,6 +44,9 @@
             ]
         }
     ],
+    "devicePermissions": [
+      "media"
+    ],
     "validDomains": [
         "eu.feedbackfruits.com",
         "accounts.feedbackfruits.com",

--- a/au/manifest.json
+++ b/au/manifest.json
@@ -53,6 +53,9 @@
             ]
         }
     ],
+    "devicePermissions": [
+      "media"
+    ],
     "validDomains": [
         "au.feedbackfruits.com",
         "au-accounts.feedbackfruits.com"

--- a/development/manifest.json
+++ b/development/manifest.json
@@ -53,6 +53,9 @@
             ]
         }
     ],
+    "devicePermissions": [
+      "media"
+    ],
     "validDomains": [
         "localhost:4200",
         "staging-accounts.feedbackfruits.com"

--- a/eu/manifest.json
+++ b/eu/manifest.json
@@ -53,6 +53,9 @@
             ]
         }
     ],
+    "devicePermissions": [
+      "media"
+    ],
     "validDomains": [
         "eu.feedbackfruits.com",
         "accounts.feedbackfruits.com"

--- a/staging/manifest.json
+++ b/staging/manifest.json
@@ -53,6 +53,9 @@
             ]
         }
     ],
+    "devicePermissions": [
+      "media"
+    ],
     "validDomains": [
         "staging.feedbackfruits.com",
         "staging-accounts.feedbackfruits.com"

--- a/us/manifest.json
+++ b/us/manifest.json
@@ -53,6 +53,9 @@
             ]
         }
     ],
+    "devicePermissions": [
+      "media"
+    ],
     "validDomains": [
         "us.feedbackfruits.com",
         "us-accounts.feedbackfruits.com"


### PR DESCRIPTION
Solves camera/mic not being accessible from MS Teams 

See https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/device-capabilities/native-device-permissions?tabs=mobile%2Cteamsjs-v2%2Cmobile1

[sc-59161]